### PR TITLE
use es5 builtins like Object.keys and Date.now

### DIFF
--- a/lib/valence.js
+++ b/lib/valence.js
@@ -105,11 +105,13 @@ D2L.Util = {
 			port +
 			path +
 			'?';
-		var paramList = new Array();
-		for (var p in parameters) {
-			paramList.push(p + '=' + parameters[p]);
-		}
-		targetUrl += paramList.join('&');
+
+		targetUrl += Object
+			.keys(parameters)
+			.map(function (p) {
+				return p + '=' + parameters[p];
+			})
+			.join('&');
 
 		return targetUrl;
 	},
@@ -180,21 +182,7 @@ D2L.Util = {
 	// Helper to retrieve a Valence-compatible timestamp from the local system
 	// Format should be a Unix-style timestamp, UTC timezone, expressed in seconds.
 	getTimestamp : function () {
-		var date = new Date();
-		var ts =
-			Math.round(
-				Date.UTC(
-					date.getUTCFullYear(),
-					date.getUTCMonth(),
-					date.getUTCDate(),
-					date.getUTCHours(),
-					date.getUTCMinutes(),
-					date.getUTCSeconds(),
-					date.getUTCMilliseconds()
-				) / 1000
-			);
-
-		return ts;
+		return Math.round(Date.now() / 1000);
 	},
 
 	// Calculates skew given the body of a 403 response
@@ -422,9 +410,8 @@ if (typeof window === 'undefined') { // node.js
 		hash.update(this.data);
 		return hash.digest('base64');
 	};
-	for (var X in D2L) {
-		if (D2L.hasOwnProperty(X)) {
-			exports[X] = D2L[X];
-		}
-	}
+
+	Object.keys(D2L).forEach(function (x) {
+		exports[x] = D2L[x];
+	});
 }


### PR DESCRIPTION
this is expected to be used in Node.js
any browser beyond IE8 also supports these functions
someone wanting to use it in IE8 can bring in a polyfill
