### PR TITLE
Fix for scheme parameter

### DIFF
--- a/sample/GettingStartedSample_Node.js/server.js
+++ b/sample/GettingStartedSample_Node.js/server.js
@@ -91,7 +91,7 @@ function getLmsData (req, res, next) {
 	req.lms = {
 		host: req.param('host'),
 		port: req.param('port'),
-		scheme: req.param('scheme') ? 'https:' : 'http:'
+		scheme: req.param('scheme') === 'true' ? 'https:' : 'http:'
 	};
 
 	next();


### PR DESCRIPTION
The query-string variable 'scheme', which comes from the "HTTPS?" checkbox was always being interpreted as truthy. This is because req.param('scheme') is a string ('true' or 'false') and bitg if( 'false' ) and if( 'true' ) evaluate to true.
